### PR TITLE
refactor(mui-table-row) Обновление mui-table-row

### DIFF
--- a/mui-atomic/projects/mui-atomic/src/lib/components/mui-table-head/mui-table-head.component.html
+++ b/mui-atomic/projects/mui-atomic/src/lib/components/mui-table-head/mui-table-head.component.html
@@ -1,1 +1,2 @@
-<mui-table-row class="header-row" [canExpand]="canExpand" [isHeaderRow]="true" [columnConfig]="columns" [source]="null"> </mui-table-row>
+<mui-table-row class="header-row" [hasAccordionInTable]="hasAccordionInTable" [isHeaderRow]="true" [columnConfig]="columns" [source]="null">
+</mui-table-row>

--- a/mui-atomic/projects/mui-atomic/src/lib/components/mui-table-head/mui-table-head.component.ts
+++ b/mui-atomic/projects/mui-atomic/src/lib/components/mui-table-head/mui-table-head.component.ts
@@ -11,5 +11,5 @@ import { MuiTableRowComponent } from '../mui-table-row/mui-table-row.component';
 })
 export class MuiTableHeadComponent {
   @Input() columns: MuiTableColumnDefinition[] = [];
-  @Input() canExpand: boolean = false;
+  @Input() hasAccordionInTable: boolean = false;
 }

--- a/mui-atomic/projects/mui-atomic/src/lib/components/mui-table-row/mui-table-row.component.html
+++ b/mui-atomic/projects/mui-atomic/src/lib/components/mui-table-row/mui-table-row.component.html
@@ -4,10 +4,7 @@
   }
 
   @for (cell of cells; track cell.id; let i = $index) {
-    <mui-table-cell
-      [ngStyle]="{ 'max-width.px': columnConfig[i].maxWidth || 'unset' }"
-      [class.offest-row]="(canExpand && isHeaderRow && i === 0) || (nestedLevel === 2 && i === 0)"
-    >
+    <mui-table-cell [ngStyle]="{ 'max-width.px': columnConfig[i].maxWidth || 'unset' }" [class.offest-row]="needsMoveFirstCell(i)">
       @if (isBadgeCell(cell)) {
         <mui-badge [style]="getBadgeCellStyle(cell)" [text]="cell.content!"></mui-badge>
       }

--- a/mui-atomic/projects/mui-atomic/src/lib/components/mui-table-row/mui-table-row.component.scss
+++ b/mui-atomic/projects/mui-atomic/src/lib/components/mui-table-row/mui-table-row.component.scss
@@ -35,7 +35,7 @@
 }
 
 .offest-row {
-  margin-inline-start: 2.5em;
+  margin-inline-start: 2.2em;
 }
 
 .icon {

--- a/mui-atomic/projects/mui-atomic/src/lib/components/mui-table-row/mui-table-row.component.ts
+++ b/mui-atomic/projects/mui-atomic/src/lib/components/mui-table-row/mui-table-row.component.ts
@@ -4,7 +4,7 @@ import { MuiTableColumnDefinition, MuiTableIndexColumnDefinition, MuiTableResolv
 import { NgClass, NgStyle } from '@angular/common';
 import { MuiBadgeTableCell, MuiTableCell } from '../mui-table-cell/mui-table-cell';
 import { MuiBadgeComponent } from '../mui-badge/mui-badge.component';
-import { ChevronMuiIconComponent } from '../mui-icon/items/chevron.mui-icon';
+import { ChevronMuiIconComponent } from '../mui-icon';
 
 export type RowIndex = {
   prefix: number;
@@ -22,6 +22,7 @@ export type NestedLevel = 0 | 1 | 2;
 })
 export class MuiTableRowComponent implements OnInit {
   @Input() canExpand = false;
+  @Input() hasAccordionInTable: boolean = false;
   @Input() source!: any;
   @Input() isHeaderRow = false;
   @Input() rowIndex: RowIndex | null = null;
@@ -107,5 +108,13 @@ export class MuiTableRowComponent implements OnInit {
     const pageIndex = decimal + itemNumber;
 
     return this.rowIndex.postfix ? `${pageIndex}${this.rowIndex.postfix}` : pageIndex;
+  }
+
+  protected needsMoveFirstCell(cellId: number): boolean {
+    const isHeaderWithAccrotionInTable = this.hasAccordionInTable && this.isHeaderRow && cellId === 0;
+    const isNestedRow = this.nestedLevel === 2 && cellId === 0;
+    const isAccordionRow = this.hasAccordionInTable && !this.canExpand && cellId === 0;
+
+    return isAccordionRow || isHeaderWithAccrotionInTable || isNestedRow;
   }
 }


### PR DESCRIPTION
### Изменения:
- Переработан флаг для установки отступа в первой ячейке строки таблицы. Флаг нужен чтобы данные в строках таблицы с аккордеоном и без не разъезжались.